### PR TITLE
Network connection problem between containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM monius/docker-warp-socks:meta
 ENV LOG=0
 
+RUN apt-get -qq update \
+    && apt-get -qq install dnsmasq \
+    && apt-get -qq autoremove --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /run/entrypoint.sh
 ENTRYPOINT ["/run/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM monius/docker-warp-socks:meta
 ENV LOG=0
 
 RUN apt-get -qq update \
-    && apt-get -qq install dnsmasq \
+    && apt-get -qq install dnsmasq shadowsocks-libev \
     && apt-get -qq autoremove --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /run/entrypoint.sh
 ENTRYPOINT ["/run/entrypoint.sh"]
 
-CMD ["danted"]
+CMD ["ss-local", "-c", "/etc/shadowsocks-libev/dws_config.json"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+sleep 5
+
 IFACE=$(ip route show default | awk '{print $5}')
 
 if [ ! -e "/opt/wgcf-profile.conf" ]; then
@@ -47,7 +49,7 @@ CURRENT_NAMESERVER=$(grep "nameserver" /etc/resolv.conf | awk '{print $2}')
 cp /etc/resolv.conf /etc/resolv.conf.backup
 
 # Configure dnsmasq
-echo -e "no-resolv\nserver=1.1.1.1\nserver=$CURRENT_NAMESERVER" | tee /etc/dnsmasq.conf
+echo -e "no-resolv\nall-servers\nserver=1.1.1.1\nserver=$CURRENT_NAMESERVER" | tee /etc/dnsmasq.conf
 
 # Restart dnsmasq
 service dnsmasq restart


### PR DESCRIPTION
Hello,

I've pinpointed two core issues in the current implementation that prevent it from connecting with other containers through Docker-Warp-Socks. Below, I've detailed these problems along with proposed solutions:

## Identified Problems:

1. **DNS Resolution Issue**: 
   The DNS setup in `/etc/resolv.conf`, specifically pointing to `1.1.1.1`, obstructs the ability to locate other containers' IP addresses using their names.

2. **Device Specification in Dante**: 
   Dante does not facilitate device non-specification, preventing the utilization of inherent OS behavior, which seems to be the most straightforward solution at the moment. This issue can be substantiated using various `curl` commands within the DWS container: `curl --interface eth0`, `curl --interface warp`, and simply, `curl`.

## Proposed Solutions:

1. **Integrate dnsmasq**: 
   Implement `dnsmasq` to allow DNS queries to both the `1.1.1.1` server and the Docker network gateway.

2. **Adopt shadowsocks-libev**: 
   Introduce `shadowsocks-libev` to overcome the device specification constraint in Dante, enabling the exploitation of native OS behavior.

I have documented both the problems and solutions here: [Docker-Warp-Socks Test Repository](https://github.com/flrngel/docker-warp-socks-test).

Kindly share your thoughts.