### PR TITLE
fix(v5): add gcompat to fix sing-box execution on Alpine

### DIFF
--- a/dev/v5/Dockerfile
+++ b/dev/v5/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer="M0nius <m0niusplus@gmail.com>" \
     org.opencontainers.image.base.name="docker.io/monius/docker-warp-socks"
 
 RUN apk update && apk upgrade \
-    && apk add --no-cache curl openssl jq tar \
+    && apk add --no-cache curl openssl jq tar gcompat \
     && rm -rf /var/cache/apk/*
 
 RUN set -e; \


### PR DESCRIPTION
Hi

Here's a small fix for `sing-box` execution failure in v5.

**Problem:**
`sing-box` fails to start with error:
```
/usr/bin/rws-cli-v5: line 1: sing-box: not found
```
The binary exists but cannot execute due to missing glibc dynamic linker.

**Solution:**
Add `gcompat` package to provide glibc compatibility on Alpine.

e.g.:
```dockerfile
RUN apk add --no-cache curl openssl jq tar gcompat
```

**Testing:**
- [x] Built and tested on `linux/amd64`
- [x] `sing-box -v` outputs version correctly

Only modified `dev/v5/Dockerfile`.